### PR TITLE
Add check for max array length

### DIFF
--- a/javasource/csv/actions/ReadNextLine.java
+++ b/javasource/csv/actions/ReadNextLine.java
@@ -83,7 +83,9 @@ public class ReadNextLine extends CustomJavaAction<IMendixObject>
 		
 		IMendixObject result = Core.instantiate(getContext(), this.entity);
 		int counter = 0;
+		int maxCount = line.length;
 		for (String attributeName : attributeNames) {
+			if (counter == maxCount) return result;
 			result.setValue(getContext(), attributeName, line[counter]);
 			counter++;
 		}


### PR DESCRIPTION
This prevents an error if your csv has fewer columns than your entity has attributes