### PR TITLE
Use getMetaPrimitives instead of getDeclaredMetaPrimitives

### DIFF
--- a/javasource/csv/actions/ReadNextLine.java
+++ b/javasource/csv/actions/ReadNextLine.java
@@ -63,7 +63,7 @@ public class ReadNextLine extends CustomJavaAction<IMendixObject>
 		CSVReader reader = (CSVReader) contextObj;
 
 		// This is implemented because declared primitives are returned in a different order than declared within the model.
-		Collection<? extends IMetaPrimitive> attributes = Core.getMetaObject(this.entity).getDeclaredMetaPrimitives();
+		Collection<? extends IMetaPrimitive> attributes = Core.getMetaObject(this.entity).getMetaPrimitives();
 		List<String> attributeNames = new LinkedList<String>();
 		for (IMetaPrimitive attribute : attributes) {
 			String name = attribute.getName();


### PR DESCRIPTION
I think it makes more sense in most cases to also take the attributes from the generalization of the entity.
If you don't want any generalized attributes, you can just not generalize the entity. 